### PR TITLE
Test legendsviewer-next

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -6433,6 +6433,13 @@
     githubId = 39825;
     name = "Dominik Honnef";
   };
+  donottellmetonottellyou = {
+    name = "Jade Masker";
+    email = "donottellmetonottellyou@gmail.com";
+    github = "donottellmetonottellyou";
+    githubId = 115233539;
+    keys = [ { fingerprint = "5C8B 7128 4AB3 000D 4AC6  6234 9B81 35A2 4A75 CB86"; } ];
+  };
   donovanglover = {
     github = "donovanglover";
     githubId = 2374245;

--- a/pkgs/by-name/le/legendsviewer-next/deps.json
+++ b/pkgs/by-name/le/legendsviewer-next/deps.json
@@ -1,0 +1,107 @@
+[
+  {
+    "pname": "coverlet.collector",
+    "version": "6.0.0",
+    "hash": "sha256-IEmweTMapcPhFHpmJsPXfmMhravYOrWupgjeOvMmQ4o="
+  },
+  {
+    "pname": "Microsoft.CodeCoverage",
+    "version": "17.8.0",
+    "hash": "sha256-cv/wAXfTNS+RWEsHWNKqRDHC7LOQSSdFJ1a9cZuSfJw="
+  },
+  {
+    "pname": "Microsoft.Extensions.ApiDescription.Server",
+    "version": "6.0.5",
+    "hash": "sha256-RJjBWz+UHxkQE2s7CeGYdTZ218mCufrxl0eBykZdIt4="
+  },
+  {
+    "pname": "Microsoft.NET.Test.Sdk",
+    "version": "17.8.0",
+    "hash": "sha256-uz7QvW+NsVRsp8FR1wjnGEOkUaPX4JyieywvCN6g2+s="
+  },
+  {
+    "pname": "Microsoft.OpenApi",
+    "version": "1.6.14",
+    "hash": "sha256-dSJUic2orPGfYVgto9DieRckbtLpPyxHtf+RJ2tmKPM="
+  },
+  {
+    "pname": "Microsoft.TestPlatform.ObjectModel",
+    "version": "17.8.0",
+    "hash": "sha256-9TwGrjVvbtyetw67Udp3EMK5MX8j0RFRjduxPCs9ESw="
+  },
+  {
+    "pname": "Microsoft.TestPlatform.TestHost",
+    "version": "17.8.0",
+    "hash": "sha256-+CTYFu631uovLCO47RKe86YaAqfoLA4r73vKORJUsjg="
+  },
+  {
+    "pname": "MSTest.TestAdapter",
+    "version": "3.1.1",
+    "hash": "sha256-TLysbO9bgiztIap44o875ZPpuVAOC6ueaRTKsiVicXg="
+  },
+  {
+    "pname": "MSTest.TestFramework",
+    "version": "3.1.1",
+    "hash": "sha256-Vqu+IDuYjiR39QOJW7GHiH7CeF2cBfNIYYTXmVeeb9E="
+  },
+  {
+    "pname": "Newtonsoft.Json",
+    "version": "13.0.1",
+    "hash": "sha256-K2tSVW4n4beRPzPu3rlVaBEMdGvWSv/3Q1fxaDh4Mjo="
+  },
+  {
+    "pname": "NuGet.Frameworks",
+    "version": "6.5.0",
+    "hash": "sha256-ElqfN4CcKxT3hP2qvxxObb4mnBlYG89IMxO0Sm5oZ2g="
+  },
+  {
+    "pname": "SkiaSharp",
+    "version": "2.88.8",
+    "hash": "sha256-rD5gc4SnlRTXwz367uHm8XG5eAIQpZloGqLRGnvNu0A="
+  },
+  {
+    "pname": "SkiaSharp.NativeAssets.Linux",
+    "version": "2.88.8",
+    "hash": "sha256-fOmNbbjuTazIasOvPkd2NPmuQHVCWPnow7AxllRGl7Y="
+  },
+  {
+    "pname": "SkiaSharp.NativeAssets.macOS",
+    "version": "2.88.8",
+    "hash": "sha256-CdcrzQHwCcmOCPtS8EGtwsKsgdljnH41sFytW7N9PmI="
+  },
+  {
+    "pname": "SkiaSharp.NativeAssets.Win32",
+    "version": "2.88.8",
+    "hash": "sha256-b8Vb94rNjwPKSJDQgZ0Xv2dWV7gMVFl5GwTK/QiZPPM="
+  },
+  {
+    "pname": "Swashbuckle.AspNetCore",
+    "version": "6.9.0",
+    "hash": "sha256-fmJjAfVHzbw/31IFPFUP31g46Y1XXIc1kr6VvYW5pCc="
+  },
+  {
+    "pname": "Swashbuckle.AspNetCore.Swagger",
+    "version": "6.9.0",
+    "hash": "sha256-8KM21CWckFghGaqWahMa3V64+hUBrifAJnQ6P2VXlEk="
+  },
+  {
+    "pname": "Swashbuckle.AspNetCore.SwaggerGen",
+    "version": "6.9.0",
+    "hash": "sha256-Ni8Z9CFs+ybTX8IgDuSKA580ISQ55w032EeqWYQXwoc="
+  },
+  {
+    "pname": "Swashbuckle.AspNetCore.SwaggerUI",
+    "version": "6.9.0",
+    "hash": "sha256-V+3bEEpxSXPi9Sy1hHZEjY9qxuIpRWV5dKzaqYMSu40="
+  },
+  {
+    "pname": "System.Reflection.Metadata",
+    "version": "1.6.0",
+    "hash": "sha256-JJfgaPav7UfEh4yRAQdGhLZF1brr0tUWPl6qmfNWq/E="
+  },
+  {
+    "pname": "System.Text.Encoding.CodePages",
+    "version": "8.0.0",
+    "hash": "sha256-fjCLQc1PRW0Ix5IZldg0XKv+J1DqPSfu9pjMyNBp7dE="
+  }
+]

--- a/pkgs/by-name/le/legendsviewer-next/frontend.nix
+++ b/pkgs/by-name/le/legendsviewer-next/frontend.nix
@@ -1,0 +1,21 @@
+{
+  buildNpmPackage,
+  nodejs,
+
+  legendsviewer-next,
+}:
+buildNpmPackage rec {
+  pname = "legends-viewer-frontend";
+  version = legendsviewer-next.version;
+
+  npmDepsHash = "sha256-pnhjGlss8U18fK4VKCPiM9kKhmUaJMMBcDOqA/Bexj4=";
+
+  src = "${legendsviewer-next.src}/LegendsViewer.Frontend/${pname}";
+
+  inherit nodejs;
+
+  installPhase = ''
+    mkdir -p $out
+    cp -r ./dist $out
+  '';
+}

--- a/pkgs/by-name/le/legendsviewer-next/package.nix
+++ b/pkgs/by-name/le/legendsviewer-next/package.nix
@@ -1,0 +1,115 @@
+{
+  lib,
+  buildDotnetModule,
+  buildNpmPackage,
+  dotnetCorePackages,
+  fetchFromGitHub,
+  makeDesktopItem,
+  copyDesktopItems,
+  netcat,
+  nix-update-script,
+  nodejs_22,
+  runCommand,
+  writeShellScriptBin,
+
+  legendsviewer-next,
+}:
+let
+  dotnet-sdk = dotnetCorePackages.sdk_8_0;
+  dotnet-runtime = dotnetCorePackages.aspnetcore_8_0;
+  frontend = import ./frontend.nix {
+    nodejs = nodejs_22;
+    inherit buildNpmPackage legendsviewer-next;
+  };
+in
+buildDotnetModule rec {
+  pname = "legendsviewer-next";
+  version = "1.2.0";
+
+  desktopItems = [
+    (makeDesktopItem {
+      name = pname;
+      desktopName = "Legends Viewer";
+      genericName = "DF Legends Export Browser";
+      comment = meta.description;
+      icon = "${frontend}/dist/ceretelina.png";
+      tryExec = "LegendsViewer";
+      exec = "LegendsViewer";
+
+      # Until upstream supports multiple launches, we need a terminal to keep
+      # track of if it's already launched.
+      terminal = true;
+
+      categories = [
+        "Game"
+        "RolePlaying"
+        "Simulation"
+      ];
+      keywords = [
+        "df"
+        "dwarf"
+        "fortress"
+        "legends"
+        "viewer"
+      ];
+    })
+  ];
+
+  src = fetchFromGitHub {
+    owner = "Kromtec";
+    repo = "LegendsViewer-Next";
+    tag = "v${version}";
+    hash = "sha256-Fi4KARGsgDmplH/oG9OIxY2XqhHNYgUB6OxwtoTaCt4=";
+  };
+
+  nugetDeps = ./deps.json;
+  projectFile = "./LegendsViewer.Backend/LegendsViewer.Backend.csproj";
+  testProjectFile = "./LegendsViewer.Backend.Tests/LegendsViewer.Backend.Tests.csproj";
+  executables = [ meta.mainProgram ];
+  inherit dotnet-sdk dotnet-runtime;
+
+  nativeBuildInputs = [
+    # This fixes a build failure, we don't care about the frontend node build here
+    (writeShellScriptBin "npm" "")
+
+    copyDesktopItems
+  ];
+
+  installPhase = ''
+    runHook preInstall
+
+    lib=$out/lib/${pname}
+
+    mkdir -p $lib
+
+    cp ./LegendsViewer.Backend/bin/Release/net8.0/linux-x64/* $lib
+    ln -s ${frontend} $lib/${frontend.pname}
+
+    runHook postInstall
+  '';
+
+  passthru = {
+    updateScript = nix-update-script {
+      extraArgs = [ "--subpackage frontend" ];
+    };
+    tests = {
+      binds-to-port = runCommand "${pname}-test-binds-to-port" { } ''
+        timeout 2 ${legendsviewer-next}/bin/${meta.mainProgram} &
+        sleep 1
+        ${netcat}/bin/nc -v localhost 5054
+        mkdir $out
+      '';
+    };
+  };
+
+  meta = {
+    description = "Recreates Dwarf Fortress' Legends Mode from exported files";
+    homepage = "https://github.com/${src.owner}/${src.repo}";
+    license = lib.licenses.mit;
+
+    mainProgram = "LegendsViewer";
+    platforms = with lib.platforms; lib.intersectLists (darwin ++ linux) (x86_64 ++ aarch64);
+
+    maintainers = with lib.maintainers; [ donottellmetonottellyou ];
+  };
+}


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

- Add myself to maintainers list
- Add new package ([legendsviewer-next](https://github.com/Kromtec/LegendsViewer-Next))

LegendsViewer allows browsing through legends exports of the indie game Dwarf Fortress. It features maps, population breakdowns, war/battle details, and much more- extending and improving Dwarf Fortress' Legends Mode.

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [ ] [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - [x] and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - [ ] or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - [ ] made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
